### PR TITLE
Replace torchvision beta api

### DIFF
--- a/cellSAM/sam_inference.py
+++ b/cellSAM/sam_inference.py
@@ -7,7 +7,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 from torchvision.transforms.functional import resize, to_pil_image
-from torchvision import datapoints
+from torchvision import tv_tensors
 
 from .AnchorDETR.models import build_inference_model
 from segment_anything import (
@@ -115,7 +115,7 @@ class CellSAM(nn.Module):
         self.cellfinder = CellfinderAnchorDetr(config)
 
     def predict_transforms(self, imgs):
-        imgs = [datapoints.Image(img) for img in imgs]
+        imgs = [tv_tensors.Image(img) for img in imgs]
         imgs = torch.stack(imgs, dim=0)
 
         return imgs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = 'README.md'
 requires-python = '>=3.10'
 dynamic = ['version']
 dependencies = [
-    'numpy<2',
+    'numpy',
     'pyyaml',
     'scikit-image',
     'segment_anything@git+https://github.com/facebookresearch/segment-anything.git',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     'scikit-image',
     'segment_anything@git+https://github.com/facebookresearch/segment-anything.git',
     'torch',
-    'torchvision==0.15.1',
+    'torchvision',
     'tqdm',
     'pytest',
     'setuptools',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-torchvision==0.15.1
 requests
 dask[distributed]
 dask-image
 matplotlib
+torchvision
 pyyaml
 scipy
 git+https://github.com/facebookresearch/segment-anything.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ git+https://github.com/facebookresearch/segment-anything.git
 scikit-image
 scikit-learn
 torch
-numpy<2
+numpy
 tqdm
 pytest
 # Docs


### PR DESCRIPTION
The package currently hard-pins to torchvision==0.15.1 to make use of the `datapoints` API. This was removed in v0.16 in favor of `tv_tensors` moving forward. See [the torchvision v0.16 release notes](https://github.com/pytorch/vision/releases/tag/v0.16.0), [tv_tensors FAQ](https://pytorch.org/vision/stable/auto_examples/transforms/plot_tv_tensors.html#tvtensors-faq), and [tv_tensors reference](https://pytorch.org/vision/main/tv_tensors.html) for details.

This PR proposes to update to the newer, non-beta `tv_tensors` API. This is necessary in order to use the latest `torchvision`, which only started providing aarch64 wheels in v0.17 AFAICT. However; I have no idea how `datapoints` is used internally e.g. in training workflows, so I rely on the experts to determine whether or not this update works comprehensively.

Closes #30 #25