### PR TITLE
Proposal to rm `visualize` kwarg.

### DIFF
--- a/examples/plot_ep_micro.py
+++ b/examples/plot_ep_micro.py
@@ -12,7 +12,6 @@ mask = cellsam_pipeline(
     img,
     low_contrast_enhancement=False,
     use_wsi=False,
-    visualize=False,
     gauge_cell_size=False,
 )
 

--- a/examples/plot_multiplexed.py
+++ b/examples/plot_multiplexed.py
@@ -16,7 +16,6 @@ mask = cellsam_pipeline(
     img,
     low_contrast_enhancement=False,
     use_wsi=False,
-    visualize=False,
     gauge_cell_size=False,
 )
 

--- a/examples/plot_yeastnet.py
+++ b/examples/plot_yeastnet.py
@@ -12,7 +12,6 @@ mask = cellsam_pipeline(
     img,
     low_contrast_enhancement=False,
     use_wsi=False,
-    visualize=False,
     gauge_cell_size=False,
 )
 

--- a/examples/plot_yeaz.py
+++ b/examples/plot_yeaz.py
@@ -12,7 +12,6 @@ mask = cellsam_pipeline(
     img,
     low_contrast_enhancement=False,
     use_wsi=False,
-    visualize=False,
     gauge_cell_size=False,
 )
 


### PR DESCRIPTION
IMO visualization is best left to users; especially for images in this domain which often have many channels, require interactive capabilities etc.

The real question here though is: what is the purpose of `prepare_labels`? Is it important? Is there functionality in `prepare_labels` that should be applied to all data in the mask, or is it really strictly only for visualization purposes? FWIW if it *is* necessary, it needs to be refactored as the implementation is very inefficient.