### PR TITLE
API: expose cellsam_pipeline from top-level namespace.

### DIFF
--- a/cellSAM/__init__.py
+++ b/cellSAM/__init__.py
@@ -1,4 +1,5 @@
 __version__ = "0.0.dev1"
 
+from .cellsam_pipeline import cellsam_pipeline
 from .model import segment_cellular_image, get_model, get_local_model
 from .sam_inference import CellSAM

--- a/examples/plot_ep_micro.py
+++ b/examples/plot_ep_micro.py
@@ -5,7 +5,7 @@ Phase Microscopy of Mammalian Cells
 import imageio.v3 as iio
 import napari
 
-from cellSAM.cellsam_pipeline import cellsam_pipeline
+from cellSAM import cellsam_pipeline
 img = iio.imread("../sample_imgs/ep_micro.png")
 
 mask = cellsam_pipeline(

--- a/examples/plot_multiplexed.py
+++ b/examples/plot_multiplexed.py
@@ -5,7 +5,7 @@ Multiplexed Imaging: CODEX
 import imageio.v3 as iio
 import napari
 
-from cellSAM.cellsam_pipeline import cellsam_pipeline
+from cellSAM import cellsam_pipeline
 img = iio.imread("../sample_imgs/tissuenet.png")
 
 # Image is 3-channel RGB where Channel 1 (G) represents a nuclear stain

--- a/examples/plot_yeastnet.py
+++ b/examples/plot_yeastnet.py
@@ -5,7 +5,7 @@ Brightfield Microscopy: YeastNet
 import imageio.v3 as iio
 import napari
 
-from cellSAM.cellsam_pipeline import cellsam_pipeline
+from cellSAM import cellsam_pipeline
 img = iio.imread("../sample_imgs/YeastNet.png")
 
 mask = cellsam_pipeline(

--- a/examples/plot_yeaz.py
+++ b/examples/plot_yeaz.py
@@ -5,7 +5,7 @@ Phase Microscopy: Yeast
 import imageio.v3 as iio
 import napari
 
-from cellSAM.cellsam_pipeline import cellsam_pipeline
+from cellSAM import cellsam_pipeline
 img = iio.imread("../sample_imgs/YeaZ.png")
 
 mask = cellsam_pipeline(


### PR DESCRIPTION
Adds the `cellsam_pipeline` to the top-level namespace so it's easier to access.

There are a lot of other API decisions to be made. It's my impression that nothing else really should be exposed - i.e. that `cellsam_pipeline` is intended to be the only interface to the inference pipeline (see #17) but that needs confirmation from the experts @rdilip @ulisrael @m274d @damaggu .

Making `cellsam_pipeline` more visible is non-controversial so I'll go ahead and put this in.