### PR TITLE
Add example to cellsam_pipeline docstring

### DIFF
--- a/cellSAM/cellsam_pipeline.py
+++ b/cellSAM/cellsam_pipeline.py
@@ -188,7 +188,6 @@ def cellsam_pipeline(
         
         # To prevent creating model for each block
         device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        print("Warning, using standard model. For better performance, use a model trained on your data.")
         model = get_model(None)
         model = model.to(device)
         model.eval()

--- a/cellSAM/cellsam_pipeline.py
+++ b/cellSAM/cellsam_pipeline.py
@@ -142,6 +142,39 @@ def cellsam_pipeline(
         labels representing pixels corresponding to cell instances.
         Background is denoted by ``0``.
 
+    Examples
+    --------
+    Using CellSAM to segment a slice from the `~skimage.data.cells3d` dataset.
+
+    >>> import numpy as np
+    >>> import skimage
+    >>> data = skimage.data.cells3d()
+    >>> data.shape
+    (60, 2, 256, 256)
+
+    From the `~skimage.data.cells3d` docstring, ``data`` is a 3D multiplexed
+    image with dimensions ``(Z, C, X, Y)`` where the ordering of the channel
+    dimension ``C`` is ``(membrane, nuclear)``.
+    Start by extracting a 2D slice from the 3D volume. The middle slice is
+    chosen arbitrarily:
+
+    >>> img = data[30, ...]
+
+    For multiplexed images, CellSAM expects the channel ordering to be
+    ``(blank, nuclear, membrane)``:
+
+    >>> seg = np.zeros((*img.shape[1:], 3), dtype=img.dtype)
+    >>> seg[..., 1] = img[1, ...]  # nuclear channel
+    >>> seg[..., 2] = img[0, ...]  # membrane channel
+
+    Segment the image with `cellsam_pipeline`. Since this is a small image,
+    we'll set ``use_wsi=False``. We'll also forgo any pre/post-processing
+    by deactivating `low_contrast_enhancement` and `gauge_cell_size`:
+
+    >>> mask = cellsam_pipeline(
+    ...     seg, low_contrast_enhancement=False, use_wsi=False, gauge_cell_size=False
+    ... )
+
     """
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+from intersphinx_registry import get_intersphinx_mapping
 from sphinx_gallery import scrapers
 import napari
 
@@ -57,6 +58,7 @@ extensions = [
     "sphinx.ext.autosummary",  # Reference guide
     "sphinx.ext.autodoc",  # Docstring summaries
     "sphinx_gallery.gen_gallery",  # Example gallery
+    "sphinx.ext.intersphinx",  # Cross-project documentation linking
 ]
 
 sphinx_gallery_conf = {
@@ -77,6 +79,18 @@ suppress_warnings=[
 
 # Generate autosummary pages
 autosummary_generate = True
+
+# Default role
+default_role = "obj"
+
+# Intersphinx mapping
+intersphinx_mapping = get_intersphinx_mapping(
+    packages={
+        "python",
+        "numpy",
+        "skimage",
+    },
+)
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ sphinx-gallery
 napari
 pyqt6
 numpydoc
+intersphinx_registry


### PR DESCRIPTION
Adds an example to the `cellsam_pipeline` docstring to show how the function can be used in practice. The example is based on segmenting a single z-slice of the `skimage.data.cells3d()` dataset which is multiplexed. Therefore, the example has the extra advantage of demonstrating for users how images are to be formatted to match the input format cellsam expects.

This serves as yet another poor-man's integration test via the `--doctest-modules` pytest flag.

I also added intersphinx and updated the default role to get cross-project linking & link formatting to work the way it should.