### PR TITLE
DOC: Add a landing page

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,10 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile html-noplot
+
+html-noplot:
+	$(SPHINXBUILD) -D plot_gallery="False" -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) 
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,10 +20,12 @@ Installation
 
    pip install git+https://github.com/vanvalenlab/cellSAM.git
 
+.. currentmodule:: cellSAM.cellsam_pipeline
+
 Basic Usage
 -----------
 
-The primary interface to the CellSAM model is `cellsam_pipeline`, which implements
+The primary interface is :func:`cellsam_pipeline`, which implements
 the inference pipeline for the CellSAM model.
 See the :doc:`Example gallery <gallery>` for examples.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,44 @@
-CellSAM documentation
+CellSAM Documentation
 =====================
+
+Welcome to the CellSAM documentation!
+
+CellSAM is a universal model for cell segmentation.
+CellSAM achieves state-of-the-art performance on segmentation across a variety
+of cellular targets (bacteria, tissue, yeast, cell culture, etc.) and imaging
+modalities (brightfield, fluorescence, phase, multiplexed, etc.).
+
+See the `preprint`_ for more information about the model and the general
+approach to image segmentation.
+
+.. _preprint: https://www.biorxiv.org/content/10.1101/2023.11.17.567630v3
+
+Installation
+------------
+
+.. code-block:: bash
+
+   pip install git+https://github.com/vanvalenlab/cellSAM.git
+
+Basic Usage
+-----------
+
+The primary interface to the CellSAM model is `cellsam_pipeline`, which implements
+the inference pipeline for the CellSAM model.
+See the :doc:`Example gallery <gallery>` for examples.
+
+Citation
+--------
+
+.. code-block:: latex
+
+   @article{israel2023foundation,
+     title={A Foundation Model for Cell Segmentation},
+     author={Israel, Uriah and Marks, Markus and Dilip, Rohit and Li, Qilin and Schwartz, Morgan and Pradhan, Elora and Pao, Edward and Li, Shenyi and Pearson-Goulart, Alexander and Perona, Pietro and others},
+     journal={bioRxiv},
+     publisher={Cold Spring Harbor Laboratory Preprints},
+     doi = {10.1101/2023.11.17.567630},
+   }
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,8 @@ Basic Usage
 
 The primary interface is :func:`cellsam_pipeline`, which implements
 the inference pipeline for the CellSAM model.
-See the :doc:`Example gallery <gallery>` for examples.
+See the :ref:`example_gallery` for examples of CellSAM applied to different
+types of images.
 
 Citation
 --------

--- a/examples/GALLERY_HEADER.rst
+++ b/examples/GALLERY_HEADER.rst
@@ -1,2 +1,4 @@
+.. _example_gallery:
+
 Gallery
 =======


### PR DESCRIPTION
Adds a front page for the documentation. Loosely based on the README.

Rendered site here: https://rossbar.github.io/cellSAM/