### PR TITLE
CI: Setup circleci for doc build/preview/deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ jobs:
 
       - run:
           name: Build site
+          # Gallery + Tutorial w/out GPU can take a while
+          no_output_timeout: 30m
           command: |
             source venv/bin/activate
             # n = nitpicky (broken links), W = warnings as errors,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,77 @@
+version: 2.1
+jobs:
+
+  build-docs:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/python:3.12
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install dependencies
+          command: |
+            python3 -m venv venv
+            source venv/bin/activate
+            pip install --upgrade wheel setuptools pip
+            pip install -r requirements.txt
+            pip install .
+
+      - run:
+          name: Build site
+          command: |
+            source venv/bin/activate
+            # n = nitpicky (broken links), W = warnings as errors,
+            # T = full tracebacks, keep-going = run to completion even with errors
+            make -C site/ SPHINXOPTS="-nWT --keep-going" html
+
+      - store_artifacts:
+          path: site/_build/html
+
+      - persist_to_workspace:
+          root: site/_build
+          paths: html
+
+  deploy-docs:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/python:3.12
+
+    steps:
+      - checkout
+
+      - attach_workspace:
+          at: site/_build
+
+      - run:
+          name: Install deploy dependencies
+          command: python3 -m pip install --user ghp-import
+
+      - run:
+          name: Configure git
+          command: |
+            git config --global user.name "ci-doc-deploy-bot"
+            git config --global user.email "ci-doc-deploy-bot@nomail"
+            git config --global push.default simple
+
+      - add_ssh_keys:
+          fingerprints:
+            - TODO
+
+      - run:
+          name: Deploy via gh-pages
+          command: |
+            ghp-import -n -f -p -m "[skip ci] docs built of $CIRCLE_SHA1" site/_build/html
+
+workflows:
+  version: 2.1
+  build:
+    jobs:
+      - build-docs
+      - deploy-docs:
+          requires:
+            - build-docs
+          filters:
+            branches:
+              only: main

--- a/.github/workflows/circleci-artifacts-redirector.yml
+++ b/.github/workflows/circleci-artifacts-redirector.yml
@@ -3,6 +3,9 @@ on: [status]
 jobs:
    circleci_artifacts_redirector_job:
      runs-on: ubuntu-latest
+     if: "${{ github.event.context == 'ci/circleci: build_doc' }}"
+     permissions:
+       statuses: write
      name: Run CircleCI artifacts redirector
      steps:
        - name: GitHub Action step

--- a/.github/workflows/circleci-artifacts-redirector.yml
+++ b/.github/workflows/circleci-artifacts-redirector.yml
@@ -1,0 +1,14 @@
+name: Run CircleCI artifacts redirector for rendered HTML
+on: [status]
+jobs:
+   circleci_artifacts_redirector_job:
+     runs-on: ubuntu-latest
+     name: Run CircleCI artifacts redirector
+     steps:
+       - name: GitHub Action step
+         uses: scientific-python/circleci-artifacts-redirector-action@4e13a10d89177f4bfc8007a7064bdbeda848d8d1  # v1.0.0
+         with:
+           repo-token: ${{ secrets.GITHUB_TOKEN }}
+           api-token: ${{ secrets.CIRCLE_TOKEN }}
+           artifact-path: 0/_build/html/index.html
+           circleci-jobs: build-docs


### PR DESCRIPTION
Initial setup for CI/CD w/ circleci. Takes advantage of the fact that sphinx generates pure static HTML so no need for a web server.

There are a few additional things that need to be set up (e.g. deploy keys) but this will be done in steps as the jobs won't trigger until there is a config available on `master`