### PR TITLE
Replace deprecated resource_filename.

### DIFF
--- a/cellSAM/model.py
+++ b/cellSAM/model.py
@@ -8,9 +8,7 @@ import requests
 import os
 from pathlib import Path
 import yaml
-import pkgutil
-from pkg_resources import resource_filename
-
+import importlib
 
 from skimage.morphology import (
     disk,
@@ -40,7 +38,7 @@ def get_local_model(model_path: str) -> nn.Module:
     """
     Returns a loaded CellSAM model from a local path.
     """
-    config_path = resource_filename(__name__, 'modelconfig.yaml')
+    config_path = importlib.resources.files("cellSAM") / 'modelconfig.yaml'
     with open(config_path, 'r') as config_file:
         config = yaml.safe_load(config_file)
 
@@ -91,7 +89,7 @@ def get_model(model="cellsam_general", version=None) -> nn.Module:
     model_version_dir = cellsam_assets_dir / f"cellsam_v{version}"
     model_path = model_version_dir / f"{model}.pt"
 
-    config_path = resource_filename(__name__, 'modelconfig.yaml')
+    config_path = importlib.resources.files("cellSAM") / 'modelconfig.yaml'
     with open(config_path, 'r') as config_file:
         config = yaml.safe_load(config_file)
 


### PR DESCRIPTION
Replace deprecated pkg_resources usage with the [recommended pattern with importlib](https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources).