### PR TITLE
CI: Setup model caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,13 @@ jobs:
             pip install .
             pip list
 
+      - restore_cache:
+          # NOTE: The v#.# refers to the cellsam published model version.
+          # The _### postfix is intended for manual cache invalidation as necessary
+          keys:
+            - model-cache-v1.2_000
+
+
       - run:
           name: Build site
           # Gallery + Tutorial w/out GPU can take a while
@@ -34,6 +41,11 @@ jobs:
             # n = nitpicky (broken links), W = warnings as errors,
             # T = full tracebacks, keep-going = run to completion even with errors
             xvfb-run --auto-servernum make -C docs/ SPHINXOPTS="-WT --keep-going" html
+
+      - save_cache:
+          key: model-cache-v1.2_000
+          paths:
+            - ~/.deepcell
 
       - store_artifacts:
           path: docs/_build/html


### PR DESCRIPTION
Set up model caching in CircleCI so that the docs build (which requires the cellsam weights) can actually run.

The config changes are relatively simple, but getting this working requires some non-code changes. For posterity, here is the procedure:
 1. Add an active access token to the circleci project environment variable
 2. Wait a few minutes for that change to take effect
 3. Trigger a run in the main repo. NOTE: the env var isn't available on forks, so you *must* create a branch on the upstream repo (as was done with this PR, e.g.)
 4. Run the workflow once to populate the model cache
 5. Once the initial run completes successfully, trigger another run (I squashed to commits and force-pushed, e.g.)
 6. Look at the circleci logs from 5 and make sure the `restore_cache` step is working as expected.