### PR TITLE
CI: Add a scheduled CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,3 +58,14 @@ workflows:
   build:
     jobs:
       - build-docs
+  scheduled:
+    triggers:
+      - schedule:
+          # Every Thursday at 10AM UTC
+          cron: "0 10 * * 4"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-docs


### PR DESCRIPTION
Run the doc-build (including example gallery) job once a week.

Should help with cache persistence as well as catching any failures from transitive dependencies.