### PR TITLE
Add H&E example to gallery

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,9 @@ def napari_scraper(block, block_vars, gallery_conf):
 
 # NOTE: borrowed from https://github.com/napari/docs/blob/b9831f55e4c3aa012bc425a669a2ebee7abd87b7/docs/conf.py#L273
 def reset_napari(gallery_conf, fname):
+    # NOTE: dummy import to handle circular import
+    # see napari/napari#8329
+    from napari.utils import theme
     from napari.settings import get_settings
     from qtpy.QtWidgets import QApplication
 

--- a/examples/plot_HandE.py
+++ b/examples/plot_HandE.py
@@ -25,7 +25,10 @@ store = zarr.storage.FsspecStore.from_url(
 )
 z = zarr.open_group(store=store, mode="r")
 # Load H&E image into local memory
-img = z["HBM248_QRTB_362"][:]
+# Limit to upper-left quadrant to reduce CI computation load
+tilesize = 512
+img = z["HBM248_QRTB_362"][:tilesize, :tilesize, :]
+print(img.shape)
 
 # NOTE: H&E images are often RGB - CellSAM expects RGB images to
 # be condensed to a single channel, as with `skimage.color.rgb2gray`,

--- a/examples/plot_HandE.py
+++ b/examples/plot_HandE.py
@@ -1,0 +1,39 @@
+"""
+Histology - H&E Staining
+========================
+
+Applying the cellsam_pipeline to segment H&E stained images.
+
+This FOV is extracted from dataset `HBM248.QRTB.362`_ available
+on the `HuBMAP data portal`_.
+
+.. _HBM248.QRTB.362: https://portal.hubmapconsortium.org/browse/dataset/692cd314ab251e5b1b1b02a9b7a9beec
+.. _HuBMAP data portal: https://portal.hubmapconsortium.org/
+"""
+import zarr
+import skimage
+import napari
+from cellSAM import cellsam_pipeline
+# NOTE: data is stored with zarr_format 3
+assert int(zarr.__version__[0]) > 2
+
+# Access H&E image
+store = zarr.storage.FsspecStore.from_url(
+    "s3://cellsam-gallery-sample-data/sample-data.zarr",
+    storage_options={"anon": True},
+    read_only=True,
+)
+z = zarr.open_group(store=store, mode="r")
+# Load H&E image into local memory
+img = z["HBM248_QRTB_362"][:]
+
+# NOTE: H&E images are often RGB - CellSAM expects RGB images to
+# be condensed to a single channel, as with `skimage.color.rgb2gray`,
+# for example
+mask = cellsam_pipeline(skimage.color.rgb2gray(img), use_wsi=False)
+
+nim = napari.view_image(img, name="H&E image");
+nim.add_labels(mask, name="Cellsam segmentation");
+
+if __name__ == "__main__":
+    napari.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,6 @@ napari
 pyqt6
 numpydoc
 intersphinx_registry
+# Remote data access
+zarr>2
+s3fs


### PR DESCRIPTION
Adds a gallery example applying `cellsam_pipeline` to H&E data. Note that this PR doesn't touch the documentation issue related to how H&E images should be formatted. I wanted to get this in place first so that any fix for that will be "tested", at least qualitatively.

Note this is also the first example that relies on cloud-native data. I'm still working through the dev-ops-y side of that but I think I have something workable. As my confidence grows I will be updating the existing examples so we can fully separate all data from the source code.